### PR TITLE
[api] Add endpoint to query supply info per key

### DIFF
--- a/app/node_manager.py
+++ b/app/node_manager.py
@@ -210,9 +210,9 @@ class NodeManager(object):
         else:
             return {"error": "unknown action type"}
 
-    def get_home(self):
+    def get_home(self, key):
         self.logger.info("Get home")
-        return self.home.get_home()
+        return self.home.get_home(key)
 
     def get_reputation_list(self):
         self.logger.info("Get reputation list")

--- a/pages/home.py
+++ b/pages/home.py
@@ -32,13 +32,17 @@ class Home(object):
             "num_pending_requests": 0,
         }
         self.supply_info = {
+            "blocks_minted": 0,
             "blocks_minted_reward": 0,
-            "collateral_locked": 0,
+            "blocks_missing": 0,
             "blocks_missing_reward": 0,
-            "current_unlocked_supply": 0,
             "current_locked_supply": 0,
-            "total_supply": 0,
-            "blocks_missing_reward": 0,
+            "current_time": 0,
+            "current_unlocked_supply": 0,
+            "epoch": 0,
+            "in_flight_requests": 0,
+            "locked_wits_by_requests": 0,
+            "maximum_supply": 0,
         }
         self.previous_supply_info = self.supply_info
         self.latest_blocks = []
@@ -258,8 +262,8 @@ class Home(object):
 
         return value_transfers
 
-    def get_home(self):
-        self.logger.info("get_home()")
+    def get_home(self, key):
+        self.logger.info(f"get_home({key})")
 
         if not self.home_queue.empty():
             try:


### PR DESCRIPTION
I created the endpoint as described in Issue #1. I assumed I can format them any way I like as long as they return supply info as integers in WITs. As it still has to be rolled out to the actual explorer below links do not work yet, they are given here for illustrative purposes.

There are two "composite" keys you can query which are probably the ones you want to use on CMC:
1) https://witnet.network/api/supply_info?key=current_supply
    This is the sum of circulating (`current_unlocked_supply`) and locked supply (`current_locked_supply`). This is an integer with WIT as base unit.
2) https://witnet.network/api/supply_info?key=total_supply
    This is the maximum supply of 2.5B from which the burned supply due to rollbacks etc is subtracted: `maximum_supply` - `blocks_missing_reward`. Units are also WIT.

All base keys as returned by the underlying node `getSupplyInfo` RPC method can also be queried. All return value are integers and have either no unit or WIT as unit.
1) https://witnet.network/api/supply_info?key=blocks_minted
2) https://witnet.network/api/supply_info?key=blocks_minted_reward
3) https://witnet.network/api/supply_info?key=blocks_missing
4) https://witnet.network/api/supply_info?key=blocks_missing_reward
5) https://witnet.network/api/supply_info?key=current_locked_supply
6) https://witnet.network/api/supply_info?key=current_time
7) https://witnet.network/api/supply_info?key=current_unlocked_supply
8) https://witnet.network/api/supply_info?key=epoch
9) https://witnet.network/api/supply_info?key=in_flight_requests
10) https://witnet.network/api/supply_info?key=locked_wits_by_requests
11) https://witnet.network/api/supply_info?key=maximum_supply